### PR TITLE
Replacing sound due to 1.24 update  - 

### DIFF
--- a/InventoryMoveSounds/Sounds/MoveSounds/config.cpp
+++ b/InventoryMoveSounds/Sounds/MoveSounds/config.cpp
@@ -3726,8 +3726,8 @@ class CfgVehicles
 	class Grenade_Base: Inventory_Base
 	{
 		ItemMoveSounds[] = 
-		{
-			"MagRifle_empty_in_SoundSet"
+		{	// Replacing sound due to 1.24 update from MagRifle_empty_in_SoundSet to PSO11Optic_pickup_SoundSet
+			"PSO11Optic_pickup_SoundSet"
 		};	
 	};
 // Blade 
@@ -3895,8 +3895,8 @@ class CfgMagazines
 	class Magazine_Base: DefaultMagazine
 	{
 		ItemMoveSounds[] = 
-		{
-			"MagRifle_empty_in_SoundSet"
+		{	// Replacing sound due to 1.24 update from MagRifle_empty_in_SoundSet to PSO11Optic_pickup_SoundSet
+			"PSO11Optic_pickup_SoundSet"
 		};	
 	};
 	class Ammunition_Base: Magazine_Base


### PR DESCRIPTION
// Replacing sound due to 1.24 update from MagRifle_empty_in_SoundSet to PSO11Optic_pickup_SoundSet

- Line 3730
- Line 3898

Error Information:
============
[EffectSound::SoundError] :: [ERROR] :: EffectSound<b8d3840>: SoundSetName: 'MagRifle_empty_in_SoundSet' :: Invalid sound set.
Class:      'EffectSound'
Function: 'SoundError'[EffectSound::SoundError] :: [ERROR] :: EffectSound<b8d3840>: SoundSetName: 'MagRifle_empty_in_SoundSet' :: Invalid sound set.
Class:      'EffectSound'
Function: 'SoundError'